### PR TITLE
fix(NodeImage): proper SharpImage.toImageData properties

### DIFF
--- a/lib/node-image.ts
+++ b/lib/node-image.ts
@@ -38,15 +38,19 @@ class SharpImage {
   }
 
   public static toImageData(image: sharp.SharpInstance): Promise<ImageData> {
-    const metadata = image.metadata()
-    const pixels = image.clone().raw().toBuffer()
-    return Promise.all([metadata, pixels]).then(([metadata, pixels]) => ({
-      channels: 3,
-      format: ImageData.RGB,
-      width: metadata.width!,
-      height: metadata.height!,
-      data: pixels,
-    }))
+    const pixels = (image.clone().raw().toBuffer as any)({resolveWithObject: true})
+    return pixels.then((rawData: any) => {
+      const {width, height, size} = rawData.info
+      const channels = size / width / height
+
+      return {
+        channels,
+        width,
+        height,
+        format: channels === 3 ? ImageData.RGB : ImageData.GREYSCALE,
+        data: rawData.data,
+      }
+    })
   }
 }
 

--- a/test/fixtures/files.txt
+++ b/test/fixtures/files.txt
@@ -1,4 +1,5 @@
 
+expected-google-canny.jpg
 expected-google.jpg
 expected-opera-square-crop.jpg
 expected-opera-square-exact.jpg

--- a/test/node-image.test.js
+++ b/test/node-image.test.js
@@ -228,6 +228,20 @@ describe('NodeImage', () => {
         return compareToFixture(buffer, 'skater-image-data.jpg', {strict: false})
       })
     })
+
+    it('should generate valid image data for transformed image', () => {
+      return NodeImage.from(skater)
+        .greyscale()
+        .resize({width: 120, height: 120})
+        .toImageData()
+        .then(imageData => {
+          expect(imageData).to.have.property('channels', 1)
+          expect(imageData).to.have.property('format', 'k')
+          expect(imageData).to.have.property('width', 120)
+          expect(imageData).to.have.property('height', 120)
+          expect(imageData.data).to.have.length(120 * 120)
+        })
+    })
   })
 
   describe('.toBuffer', () => {
@@ -266,5 +280,23 @@ describe('NodeImage', () => {
           })
         })
     })
+  })
+
+  it('should support multiple sequential changes', () => {
+    const image = NodeImage.from(fixture('source-google.nef'))
+    expect(image).to.be.instanceOf(NodeImage)
+    return image
+      .resize({width: 604, height: 400})
+      .greyscale()
+      .edges({method: NodeImage.CANNY, blurSigma: 0})
+      .format({type: 'jpeg', quality: 80})
+      .toBuffer()
+      .then(buffer => {
+        return compareToFixture(buffer, 'google-canny.jpg', {
+          strict: false,
+          increment: 10,
+          tolerance: 30,
+        })
+      })
   })
 })


### PR DESCRIPTION
fixes issue where resizing a NodeImage and calling toImageData would return invalid results